### PR TITLE
[COOK-3312] Sort the environment variables.

### DIFF
--- a/templates/default/program.conf.erb
+++ b/templates/default/program.conf.erb
@@ -28,7 +28,7 @@ stderr_logfile_backups=<%= @prog.stderr_logfile_backups %>
 stderr_capture_maxbytes=<%= @prog.stderr_capture_maxbytes %>
 stderr_events_enabled=<%= @prog.stderr_events_enabled ? 'true' : 'false' %>
 <% unless @prog.environment.empty? %>
-environment=<%= @prog.environment.map{|k,v| "#{k}=\"#{v}\""}.join(',') %>
+environment=<%= @prog.environment.sort.map{|k,v| "#{k}=\"#{v}\""}.join(',') %>
 <% end %>
 <% if @prog.directory %>
 directory=<%= @prog.directory %>


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3312

This prevents multiple runs from causing supervisor to restart because it thinks the configuration file changed. This is necessary with versions of ruby prior to 1.9.2 when they added key order preservation.
