### PR TITLE
Pip 1.4 has dropped, no longer required.

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,6 +26,10 @@ if platform_family?("smartos")
   end
 end
 
+python_pip "Distribute" do
+  action :upgrade
+end
+
 python_pip "supervisor" do
   action :upgrade
   version node['supervisor']['version'] if node['supervisor']['version']


### PR DESCRIPTION
Also giving the following error for me:

```
================================================================================
Error executing action `upgrade` on resource 'python_pip[supervisor]'
================================================================================

Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of pip install  --upgrade supervisor ----
STDOUT: Downloading/unpacking supervisor
  Could not find a version that satisfies the requirement supervisor (from versions: 3.0a9, 3.0a11, 3.0a8, 3.0a7, 3.0a10, 3.0a12, 3.0b2, 3.0b1)
Cleaning up...
No distributions matching the version for supervisor
Storing complete log in /root/.pip/pip.log
STDERR:
---- End output of pip install  --upgrade supervisor ----
Ran pip install  --upgrade supervisor returned 1

Cookbook Trace:
---------------
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/python/providers/pip.rb:155:in `pip_cmd'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/python/providers/pip.rb:139:in `install_package'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/python/providers/pip.rb:144:in `upgrade_package'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/python/providers/pip.rb:60:in `class_from_file'
/tmp/vagrant-chef-1/chef-solo-1/cookbooks/python/providers/pip.rb:58:in `class_from_file'

Resource Declaration:
---------------------
# In /tmp/vagrant-chef-1/chef-solo-1/cookbooks/supervisor/recipes/default.rb

 34: python_pip "supervisor" do
 35:   action :upgrade
 36:   version node['supervisor']['version'] if node['supervisor']['version']
 37: end
 38:

Compiled Resource:
------------------
# Declared in /tmp/vagrant-chef-1/chef-solo-1/cookbooks/supervisor/recipes/default.rb:34:in `from_file'

python_pip("supervisor") do
  cookbook_name :supervisor
  action [:upgrade]
  recipe_name "default"
  retry_delay 2
  package_name "supervisor"
  retries 0
  options " --upgrade"
  timeout 900
end
```
