### PR TITLE
Remove extraneous newline trims for inet_http_server section

### DIFF
--- a/templates/default/supervisord.conf.erb
+++ b/templates/default/supervisord.conf.erb
@@ -11,14 +11,14 @@ chmod=0700                       ; sockef file mode (default 0700)
 
 <% unless @inet_port.nil? -%>
 [inet_http_server]
-port=<%= @inet_port -%>
+port=<%= @inet_port %>
 <%   unless @inet_username.nil? -%>
-username=<%= @inet_username -%>
+username=<%= @inet_username %>
 <%     unless @inet_password.nil? -%>
-password=<%= @inet_password -%>
+password=<%= @inet_password %>
 <%     end -%>
 <%   end -%>
-<% end -%>
+<% end %>
 
 [supervisord]
 logfile=<%= @node['supervisor']['log_dir'] %>/supervisord.log   ; (main log file;default $CWD/supervisord.log)


### PR DESCRIPTION
If you configure the default recipe with the attributes:

``` ruby
:supervisor => {
    :inet_port => "127.0.0.1:9001",
    :inet_username => "analysis",
    :inet_password => "analysis"
},
```

you will get a output in the /etc/supervisord.conf like this

```
...
[inet_http_server]
port=127.0.0.1:9001username=analysispassword=analysis
[supervisord]
...
```

With this configuration line in conf file the supervisord daemon fails to start like this

```
---- Begin output of /etc/init.d/supervisor start ----
STDOUT: Starting supervisor:
STDERR: /usr/local/lib/python2.7/dist-packages/supervisor/options.py:295: UserWarning: Supervisord is running as root and it is searching for its configuration file in default locations (including its current working directory); you probably want to specify a "-c" argument specifying an absolute path to a configuration file for improved security.
  'Supervisord is running as root and it is searching '
Error: not a valid port number: '9001username=analysispassword=analysis'
```

Solution: Remove the newline tims.
