### PR TITLE
Fix Debian init.d script

### DIFF
--- a/templates/debian/supervisor.init.erb
+++ b/templates/debian/supervisor.init.erb
@@ -91,7 +91,7 @@ force_stop() {
 case "$1" in
   start)
     echo -n "Starting $DESC: "
-    start-stop-daemon --start --quiet --pidfile $PIDFILE \
+    start-stop-daemon --start --quiet --oknodo --pidfile $PIDFILE \
                       --startas $DAEMON -- $DAEMON_OPTS
     test -f $PIDFILE || sleep 1
         if running ; then


### PR DESCRIPTION
We've run into this bug on our production Wheezy servers:
http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=609457

Proposed patch fixes the problem.
