### PR TITLE
[COOK-3655] Fix errors on start and stop actions

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -85,7 +85,7 @@ action :restart do
 end
 
 def enable_service
-  execute "supervisorctl update" do
+  e = execute "supervisorctl update" do
     action :nothing
     user "root"
   end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-3655

This fix allows the action `[:enable, :start]` to be used for supervisor_service resources.
