### PR TITLE
[COOK-3811] raise an exception if platform not supported.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 #
 
+default['supervisor']['support_required'] = true
 default['supervisor']['inet_port'] = nil
 default['supervisor']['inet_username'] = nil
 default['supervisor']['inet_password'] = nil


### PR DESCRIPTION
From the ticket [COOK-3811](https://tickets.opscode.com/browse/COOK-3811): If the supervisor recipe does not support a platform, an obscure error occurs later on when using the provider. It would be better to "fail fast."  This would make troubleshooting easier for people.
