### PR TITLE
[COOK-3955] Make the initial service actions (e.g., enable, start) attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -34,3 +34,5 @@ default['supervisor']['logfile_backups'] = 10
 default['supervisor']['loglevel'] = 'info'
 default['supervisor']['minfds'] = 1024
 default['supervisor']['minprocs'] = 200
+
+default['supervisor']['initial_service_actions'] = [:enable, :start]

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -81,7 +81,7 @@ when "debian", "ubuntu"
   end
 
   service "supervisor" do
-    action [:enable, :start]
+    action node['supervisor']['initial_service_actions']
   end
 when "smartos"
   directory "/opt/local/share/smf/supervisord" do


### PR DESCRIPTION
I don't want to automatically start supervisor when the cookbook executes. In order to stop supervisor from starting, I would like to set the actions in the service block via attributes.
