### PR TITLE
[COOK-3956] Add support for centos in the default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -65,7 +65,7 @@ directory node['supervisor']['log_dir'] do
 end
 
 case node['platform']
-when "debian", "ubuntu"
+when "debian", "ubuntu", "centos"
   template "/etc/init.d/supervisor" do
     source "supervisor.init.erb"
     owner "root"

--- a/templates/centos/supervisor.default.erb
+++ b/templates/centos/supervisor.default.erb
@@ -1,0 +1,10 @@
+# Defaults for supervisor initscript
+# sourced by /etc/init.d/supervisor
+# installed at /etc/default/supervisor by the maintainer scripts
+
+#
+# This is a POSIX shell fragment
+#
+
+# Additional options that are passed to the Daemon.
+DAEMON_OPTS="<%= @node['supervisor']['daemon_options'] %>"

--- a/templates/centos/supervisor.init.erb
+++ b/templates/centos/supervisor.init.erb
@@ -1,0 +1,63 @@
+#!/bin/bash
+#
+# supervisord   This scripts turns supervisord on
+#
+# Author:       Mike McGrath <mmcgrath@redhat.com> (based off yumupdatesd)
+#
+# chkconfig:  - 95 04
+#
+# description:  supervisor is a process control utility.  It has a web based
+#               xmlrpc interface as well as a few other nifty features.
+# processname:  supervisord
+# config: /etc/supervisord.conf
+# pidfile: /var/run/supervisord.pid
+#
+
+# source function library
+. /etc/rc.d/init.d/functions
+
+RETVAL=0
+
+start() {
+  echo -n $"Starting supervisord: "
+  daemon supervisord
+  RETVAL=$?
+  echo
+  [ $RETVAL -eq 0 ] && touch /var/lock/subsys/supervisord
+}
+
+stop() {
+  echo -n $"Stopping supervisord: "
+  killproc supervisord
+  echo
+  [ $RETVAL -eq 0 ] && rm -f /var/lock/subsys/supervisord
+}
+
+restart() {
+  stop
+  start
+}
+
+case "$1" in
+  start)
+  start
+  ;;
+  stop)
+  stop
+  ;;
+  restart|force-reload|reload)
+  restart
+  ;;
+  condrestart)
+  [ -f /var/lock/subsys/supervisord ] && restart
+  ;;
+  status)
+  status supervisord
+  RETVAL=$?
+  ;;
+  *)
+  echo $"Usage: $0 {start|stop|status|restart|reload|force-reload|condrestart}"
+  exit 1
+esac
+
+exit $RETVAL


### PR DESCRIPTION
We haven't seen any issues with adding Centos support to the supervisor cookbook. The change we've made is simply to add a supervisor init script for Centos.
