### PR TITLE
[COOK-3957] Allow setting of unix_http_server chmod and chown in supervisord.conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,8 @@
 # limitations under the License.
 #
 
+default['supervisor']['unix_http_server']['chmod'] = 0700
+default['supervisor']['unix_http_server']['chown'] = 'root:root'
 default['supervisor']['inet_port'] = nil
 default['supervisor']['inet_username'] = nil
 default['supervisor']['inet_password'] = nil

--- a/templates/default/supervisord.conf.erb
+++ b/templates/default/supervisord.conf.erb
@@ -5,8 +5,9 @@
 ;
 
 [unix_http_server]
-file=/var/run//supervisor.sock   ; (the path to the socket file)
-chmod=0700                       ; sockef file mode (default 0700)
+file=/var/run//supervisor.sock                                ; (the path to the socket file)
+chmod=<%= @node['supervisor']['unix_http_server']['chmod'] %> ; socket file mode (default 0700)
+chown=<%= @node['supervisor']['unix_http_server']['chown'] %> ; socket file uid:gid owner
 <% unless @inet_port.nil? %>
 
 [inet_http_server]


### PR DESCRIPTION
We needed to set both of these attributes in the supervisord.conf. The cookbook simply needs to be changed to allow these attributes to be set.
