### PR TITLE
Wait to start or stop a service in corresponding action if it was in state of "STARTING" or "STOPPING"

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -155,8 +155,7 @@ def load_current_resource
   @current_resource.state = get_current_state(@new_resource.name)
 end
 
-def wait_til_state(state)
-  max_tries = 20
+def wait_til_state(state,max_tries=20)
   service = new_resource.service_name
 
   max_tries.times do
@@ -167,17 +166,5 @@ def wait_til_state(state)
   end
   
   raise "service #{service} not in state #{state} after #{max_tries} tries"
-  
-
-  # for i in 0..max_tries
-  #   break if get_current_state(service) == state
-    
-  #   Chef::Log.debug("Waiting for service #{service} to be in state #{state}")
-  #   sleep 1
-  # end
-
-  # if i == max_tries
-  #   raise "service #{service} not in state #{state} after #{max_tries} tries"
-  # end
 
 end


### PR DESCRIPTION
When starting or stopping a service is possible that the service was in process to start (STARTING) or to stop (STOPPING).
With this commit the process waits until the service reaches the required state.

In my myql cookbook, when I'm trying to install mysql-server, supervised with supervisor, and create a database, the database creation fails because was unable to connect to socket.
This is because when "supervisord update" finds that a service that must be started is not, tries to start it, but not waits for this process to finish (https://github.com/Supervisor/supervisor/issues/214).  
