### PR TITLE
Make Supervisor LWRP act more like service resource

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-actions :enable, :disable, :start, :stop, :restart
+actions :enable, :disable, :start, :stop, :restart, :add, :remove
 default_action :enable
 
 attribute :service_name, :kind_of => String, :name_attribute => true
@@ -54,3 +54,10 @@ attribute :umask, :kind_of => [NilClass, String], :default => nil
 attribute :serverurl, :kind_of => String, :default => 'AUTO'
 
 attr_accessor :state
+attr_accessor :enabled
+alias_method "enabled?", :enabled
+
+def initialize(*args)
+  super
+  @enabled = @autostart
+end


### PR DESCRIPTION
NOTE:  Please do not merge this without giving it a little time for community discussion.  It is a breaking change, which will require a new major version number, but has minimal impact in most cases.

This pull request alters the behavior of the supervisor cookbook LWRP to behave more like the service resource.  Specifically, it changes the meaning of `:enable` and `:disable` so that these actions do not add or remove the supervisor configuration file, but simply turn the autostart feature on or off (as do `:enable` and `:disable` in the service resource).  I have also added an `:add` and `:remove` resource to allow for the old behavior of adding/removing the configuration file completely.  
