### PR TITLE
Allow event listeners to be configured with the supervisor_service resource

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -54,7 +54,7 @@ attribute :umask, :kind_of => [NilClass, String], :default => nil
 attribute :serverurl, :kind_of => String, :default => 'AUTO'
 
 attribute :eventlistener, :kind_of => [TrueClass,FalseClass], :default => false
-attribute :buffer_size, :kind_of => Integer, :default => nil
-attribute :events, :kind_of => Array, :default => nil
+attribute :eventlistener_buffer_size, :kind_of => Integer, :default => nil
+attribute :eventlistener_events, :kind_of => Array, :default => nil
 
 attr_accessor :state

--- a/templates/default/program.conf.erb
+++ b/templates/default/program.conf.erb
@@ -38,9 +38,9 @@ directory=<%= @prog.directory %>
 umask=<%= @prog.umask %>
 <% end %>
 serverurl=<%= @prog.serverurl %>
-<% unless @prog.events.nil? or @prog.events.empty? %>
-events=<%= @prog.events.join(',') %>
+<% unless @prog.eventlistener_events.nil? or @prog.eventlistener_events.empty? %>
+events=<%= @prog.eventlistener_events.join(',') %>
 <% end %>
-<% unless @prog.buffer_size.nil? %>
-buffer_size=<%= @prog.buffer_size %>
+<% unless @prog.eventlistener_buffer_size.nil? %>
+buffer_size=<%= @prog.eventlistener_buffer_size %>
 <% end %>


### PR DESCRIPTION
http://supervisord.org/events.html#event-listeners-and-event-notifications
