### PR TITLE
skip setuptools upgrade

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -26,11 +26,6 @@ if platform_family?("smartos")
   end
 end
 
-# Until pip 1.4 drops, see https://github.com/pypa/pip/issues/1033
-python_pip "setuptools" do
-  action :upgrade
-end
-
 python_pip "supervisor" do
   action :upgrade
   version node['supervisor']['version'] if node['supervisor']['version']


### PR DESCRIPTION
This ends up being done in the python recipe and here, both needlessly now that the current get-pip.py script installs the latest version for us.
