### PR TITLE
Adds killasgroup option to program.conf template

### DIFF
--- a/templates/default/program.conf.erb
+++ b/templates/default/program.conf.erb
@@ -14,6 +14,9 @@ stopwaitsecs=<%= @prog.stopwaitsecs %>
 <% unless @prog.stopasgroup.nil? %>
 stopasgroup=<%= @prog.stopasgroup %>
 <% end %>
+<% unless @prog.killasgroup.nil? %>
+killasgroup=<%= @prog.killasgroup %>
+<% end %>
 <% if @prog.user %>
 user=<%= @prog.user %>
 <% end %>


### PR DESCRIPTION
The "killasgroup" option was part of the LWRP, but never added to the appropriate section of the program templates.  This addresses that problem.
