### PR TITLE
Improve startup security

### DIFF
--- a/templates/default/debian/supervisor.default.erb
+++ b/templates/default/debian/supervisor.default.erb
@@ -7,4 +7,4 @@
 #
 
 # Additional options that are passed to the Daemon.
-DAEMON_OPTS="<%= @node['supervisor']['daemon_options'] %>"
+DAEMON_OPTS="-c <%= node['supervisor']['conffile'] %> <%= @node['supervisor']['daemon_options'] %>"


### PR DESCRIPTION
Currently, when run as root, supervisord issues a warning if the `-c` flag has not been set. The reasons for which are explained here: http://supervisord.org/running.html#running-supervisord

There are two solutions to this, first is for users to set `-c` in `node.supervisor.daemon_options`, the second is to to make the reasonable assumption that the config supervisord should use is the one created by the cookbook, and set it automatically.

The second approach is the one take by this PR.

Unfortunately supervisord will throw an error when starting if there are multiple `-c` flags, so a hybrid approach would involve detecting the `-c` flag in `daemon_options`.

Happy to take this in a another direction based on feedback, if it's not wanted as is.
