### PR TITLE
Bring rhel init script into agreement

### DIFF
--- a/templates/default/rhel/supervisor.init.erb
+++ b/templates/default/rhel/supervisor.init.erb
@@ -16,7 +16,7 @@ start() {
     echo -n "Starting supervisor: "
     # status() returns 0 if and only if the service is properly started.
     status supervisord > /dev/null && echo "already running" && return 0
-    daemon "<%= @supervisord %> -c <%= node['supervisor']['conffile'] %>"
+    daemon "<%= @supervisord %> -c <%= node['supervisor']['conffile'] %> <%= @node['supervisor']['daemon_options'] %>"
     RETVAL=$?
     echo
     [ $RETVAL -ne 0 ] && return $RETVAL


### PR DESCRIPTION
Added `daemon_options`, now matches init scripts for debian and smartos
