### PR TITLE
Fix issue with directory creation

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -35,6 +35,7 @@ directory node['supervisor']['dir'] do
   owner "root"
   group "root"
   mode "755"
+  recursive true
 end
 
 template node['supervisor']['conffile'] do


### PR DESCRIPTION
This PR avoid this problem:

```
================================================================================
Error executing action `create` on resource 'directory[/etc/supervisor/conf.d]'
================================================================================

Chef::Exceptions::EnclosingDirectoryDoesNotExist
------------------------------------------------
Parent directory /etc/supervisor does not exist, cannot create /etc/supervisor/conf.d

Resource Declaration:
---------------------

 39: directory node['supervisor']['dir'] do
 40:   owner "root"
 41:   group "root"
 42:   mode "755"
 43: end
 44:

Compiled Resource:
------------------

directory("/etc/supervisor/conf.d") do
  provider Chef::Provider::Directory
  action :create
  retries 0
  retry_delay 2
  path "/etc/supervisor/conf.d"
  mode "755"
  cookbook_name :supervisor
  recipe_name "default"
  owner "root"
  group "root"
end
```
