### PR TITLE
Remove Supervisor Service Based On File

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -107,7 +107,7 @@ def disable_service
     user "root"
   end
 
-  if File.exists?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
+  if ::File.exists?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
 	  file "#{node['supervisor']['dir']}/#{new_resource.service_name}.conf" do
 		action :delete
 		notifies :run, "execute[supervisorctl update]", :immediately

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -25,13 +25,9 @@ action :enable do
 end
 
 action :disable do
-  if current_resource.state == 'UNAVAILABLE'
-    Chef::Log.info "#{new_resource} is already disabled."
-  else
     converge_by("Disabling #{new_resource}") do
       disable_service
     end
-  end
 end
 
 action :start do
@@ -114,6 +110,7 @@ def disable_service
   file "#{node['supervisor']['dir']}/#{new_resource.service_name}.conf" do
     action :delete
     notifies :run, "execute[supervisorctl update]", :immediately
+    not_if !File.exist?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
   end
 end
 

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -107,10 +107,11 @@ def disable_service
     user "root"
   end
 
-  file "#{node['supervisor']['dir']}/#{new_resource.service_name}.conf" do
-    action :delete
-    notifies :run, "execute[supervisorctl update]", :immediately
-    not_if !File.exists?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
+  if File.exists?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
+	  file "#{node['supervisor']['dir']}/#{new_resource.service_name}.conf" do
+		action :delete
+		notifies :run, "execute[supervisorctl update]", :immediately
+	  end
   end
 end
 

--- a/providers/service.rb
+++ b/providers/service.rb
@@ -110,7 +110,7 @@ def disable_service
   file "#{node['supervisor']['dir']}/#{new_resource.service_name}.conf" do
     action :delete
     notifies :run, "execute[supervisorctl update]", :immediately
-    not_if !File.exist?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
+    not_if !File.exists?("#{node['supervisor']['dir']}/#{new_resource.service_name}.conf")
   end
 end
 


### PR DESCRIPTION
This fixes #71 and bases the disable function on the conf file existing instead of the unreliable status command.