### PR TITLE
Use system package on arch platform (Arch Linux)

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,9 @@
 # limitations under the License.
 #
 
-include_recipe "python"
+unless platform_family?("arch")
+  include_recipe "python"
+end
 
 # foodcritic FC023: we prefer not having the resource on non-smartos
 if platform_family?("smartos")


### PR DESCRIPTION
Arch Linux has [supervisor](https://www.archlinux.org/packages/community/any/supervisor/) in the official repositories.

Tested with default settings, seems to be working just fine. :smiley: :fireworks:
