### PR TITLE
supervisor service should subscribe to supervisord.conf

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -91,6 +91,7 @@ when "amazon", "centos", "debian", "fedora", "redhat", "ubuntu"
   service "supervisor" do
     supports :status => true, :restart => true
     action [:enable, :start]
+    subscribes :restart, "template[#{node['supervisor']['conffile']}]"
   end
 when "smartos"
   directory "/opt/local/share/smf/supervisord" do


### PR DESCRIPTION
Hi there,

Thanks for everybody who contributed to the cookbook.

Currently, if you change the inet port for example, supervisor will not pick it up until the service is actually restarted.

Thanks for looking at it.
