### PR TITLE
Added ctlplugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,19 @@ Attributes
 - `node['supervisor']['minprocs']` - The minimum number of process descriptors that must be available before supervisord will start successfully.
 - `node['supervisor']['version']` - Sets the version of supervisor to install, must be 3.0+ to use minprocs and minfds.
 - `node['supervisor']['socket_file']` - location of supervisor socket file.
+- `node['supervisor']['ctlplugins']` - entries for `supervisorctl` plugins.
+  For instance, to install [serialrestart](https://pypi.python.org/pypi/supervisor-serialrestart), you'd manually add this to your config:
+
+    ```text
+    [ctlplugin:serialrestart]
+    supervisor.ctl_factory = supervisorserialrestart.controllerplugin:make_serialrestart_controllerplugin
+	```	
+  Which can be achieved using
+    ```ruby
+	node.default['supervisor']['ctlplugins'] = ({
+	 'serialrestart'=> 'supervisorserialrestart.controllerplugin:make_serialrestart_controllerplugin'
+     })
+	 ```
 
 
 Resources/Providers

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -37,3 +37,4 @@ default['supervisor']['loglevel'] = 'info'
 default['supervisor']['minfds'] = 1024
 default['supervisor']['minprocs'] = 200
 default['supervisor']['socket_file'] = '/var/run/supervisor.sock'
+default['supervisor']['ctlplugins'] = {}

--- a/templates/default/supervisord.conf.erb
+++ b/templates/default/supervisord.conf.erb
@@ -49,5 +49,13 @@ serverurl=unix:///var/run//supervisor.sock ; use a unix:// URL  for a unix socke
 ; interpreted as relative to this file.  Included files *cannot*
 ; include files themselves.
 
+
+<% @node['supervisor']['ctlplugins'] && @node['supervisor']['ctlplugins'].each do |k,v| %>
+
+[ctlplugin:<%=k%>]
+<%=v%>
+
+<%end%>
+
 [include]
 files = <%= @node['supervisor']['dir'] %>/*.conf


### PR DESCRIPTION
Added support for ctlplugins in the `supervisord.conf` file.
These settings can't be set in sperate included files (I checked).

Testing passed using kitchen.
