### PR TITLE
RHEL init.d script will detect a different instance of supervisord if something else is running it.

### DIFF
--- a/templates/default/rhel/supervisor.init.erb
+++ b/templates/default/rhel/supervisor.init.erb
@@ -29,7 +29,7 @@ start() {
     echo -n "Starting supervisor: "
     # status() returns 0 if and only if the service is properly started.
     status > /dev/null && echo "already running" && return 0
-    daemon "<%= @supervisord %> -c <%= node['supervisor']['conffile'] %> <%= @node['supervisor']['daemon_options'] %> -p $PIDFILE"
+    daemon "<%= @supervisord %> -c <%= node['supervisor']['conffile'] %> <%= @node['supervisor']['daemon_options'] %> --pidfile=$PIDFILE"
     RETVAL=$?
     echo
     [ $RETVAL -ne 0 ] && return $RETVAL


### PR DESCRIPTION
I am running the datadog agent on my box, which uses supervisord. They namespace all of their config and install their own supervisor app, but the `status` command on RHEL returns that programs pid rather than the instance I am trying to install and manage.
