### PR TITLE
converge_by is not needed when only platform resources are used

### DIFF
--- a/providers/service.rb
+++ b/providers/service.rb
@@ -19,18 +19,14 @@
 #
 
 action :enable do
-  converge_by("Enabling #{ new_resource }") do
-    enable_service
-  end
+  enable_service
 end
 
 action :disable do
   if current_resource.state == 'UNAVAILABLE'
     Chef::Log.info "#{new_resource} is already disabled."
   else
-    converge_by("Disabling #{new_resource}") do
-      disable_service
-    end
+    disable_service
   end
 end
 


### PR DESCRIPTION
(http://docs.chef.io/lwrp_custom_provider.html). converge_by always
marks the custom resource as updated which may send spurious
notifications when nothing actually changed.