### PR TITLE
Add action reread

### DIFF
--- a/resources/service.rb
+++ b/resources/service.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-actions :enable, :disable, :start, :stop, :restart
+actions :enable, :disable, :start, :stop, :restart, :reread
 default_action :enable
 
 attribute :service_name, :kind_of => String, :name_attribute => true


### PR DESCRIPTION
Added the action itself to the resources and providers.

Upon a template updating or creating the reread action will prevent a restart of all of the supervisors.
( I have also added the matcher library for the service).