### PR TITLE
Made CentOS platform use rhel init.d script

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -70,7 +70,7 @@ template "/etc/default/supervisor" do
 end
 
 init_template_dir = value_for_platform_family(
-  ["rhel", "fedora"] => "rhel",
+  ["rhel", "fedora", "centos", "amazon"] => "rhel",
   "debian" => "debian"
 )
 


### PR DESCRIPTION
Without this supervisor is not added as system service in CentOS platforms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/poise/supervisor/91)
<!-- Reviewable:end -->
