### PR TITLE
Attribute support for owner, group, mode on conf dir

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,6 +30,9 @@ else
   default['supervisor']['dir'] = '/etc/supervisor.d'
   default['supervisor']['conffile'] = '/etc/supervisord.conf'
 end
+default['supervisor']['dir_owner'] = 'root'
+default['supervisor']['dir_group'] = 'root'
+default['supervisor']['dir_mode'] = '755'
 default['supervisor']['log_dir'] = '/var/log/supervisor'
 default['supervisor']['logfile_maxbytes'] = '50MB'
 default['supervisor']['logfile_backups'] = 10

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs supervisor and provides resources to configure services"
-version           "0.4.12"
+version           "0.4.13"
 
 recipe "supervisor", "Installs and configures supervisord"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -32,9 +32,9 @@ python_pip "supervisor" do
 end
 
 directory node['supervisor']['dir'] do
-  owner "root"
-  group "root"
-  mode "755"
+  owner node['supervisor']['dir_owner']
+  group node['supervisor']['dir_group']
+  mode node['supervisor']['dir_mode']
   recursive true
 end
 


### PR DESCRIPTION
Allow a user to specify owner, group and mode on the supervisor config dir.

This is to allow other deployment processes to drop supervisor configs here.
