### PR TITLE
Allow setting of nocleanup flag in supervisord.conf

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Attributes
 - `node['supervisor']['loglevel']` - the minimum severity for those log messages, default `'info'`
 - `node['supervisor']['minfds']` - The minimum number of file descriptors that must be available before supervisord will start successfully.
 - `node['supervisor']['minprocs']` - The minimum number of process descriptors that must be available before supervisord will start successfully.
-- `node['supervisor']['version']` - Sets the version of supervisor to install, must be 3.0+ to use minprocs and minfds.
+- `node['supervisor']['nocleanup']` - If true, retain child log files at startup, the default is false
+- `node['supervisor']['version']` - Sets the version of supervisor to install, must be 3.0+ to use minprocs, minfds and nocleanup.
 - `node['supervisor']['socket_file']` - location of supervisor socket file.
 - `node['supervisor']['ctlplugins']` - entries for `supervisorctl` plugins.
   For instance, to install [serialrestart](https://pypi.python.org/pypi/supervisor-serialrestart), you'd manually add this to your config:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,7 +36,6 @@ default['supervisor']['logfile_backups'] = 10
 default['supervisor']['loglevel'] = 'info'
 default['supervisor']['minfds'] = 1024
 default['supervisor']['minprocs'] = 200
-# if true, retain child log files at startup, default false
 default['supervisor']['nocleanup'] = false
 default['supervisor']['socket_file'] = '/var/run/supervisor.sock'
 default['supervisor']['ctlplugins'] = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,6 +31,7 @@ else
   default['supervisor']['conffile'] = '/etc/supervisord.conf'
 end
 default['supervisor']['log_dir'] = '/var/log/supervisor'
+default['supervisor']['nocleanup'] = false
 default['supervisor']['logfile_maxbytes'] = '50MB'
 default['supervisor']['logfile_backups'] = 10
 default['supervisor']['loglevel'] = 'info'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -31,11 +31,12 @@ else
   default['supervisor']['conffile'] = '/etc/supervisord.conf'
 end
 default['supervisor']['log_dir'] = '/var/log/supervisor'
-default['supervisor']['nocleanup'] = false
 default['supervisor']['logfile_maxbytes'] = '50MB'
 default['supervisor']['logfile_backups'] = 10
 default['supervisor']['loglevel'] = 'info'
 default['supervisor']['minfds'] = 1024
 default['supervisor']['minprocs'] = 200
+# if true, retain child log files at startup, default false
+default['supervisor']['nocleanup'] = false
 default['supervisor']['socket_file'] = '/var/run/supervisor.sock'
 default['supervisor']['ctlplugins'] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs supervisor and provides resources to configure services"
-version           "0.4.12"
+version           "0.4.13"
 
 recipe "supervisor", "Installs and configures supervisord"
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -49,6 +49,7 @@ template node['supervisor']['conffile'] do
     :inet_password => node['supervisor']['inet_password'],
     :supervisord_minfds => node['supervisor']['minfds'],
     :supervisord_minprocs => node['supervisor']['minprocs'],
+    :supervisord_nocleanup => node['supervisor']['nocleanup'],
     :supervisor_version => node['supervisor']['version'],
     :socket_file => node['supervisor']['socket_file'],
   })

--- a/templates/default/supervisord.conf.erb
+++ b/templates/default/supervisord.conf.erb
@@ -27,6 +27,7 @@ logfile_backups=<%= @node['supervisor']['logfile_backups'] %>   ; number of back
 loglevel=<%= @node['supervisor']['loglevel'] %>                 ; critical, error, warn, info, debug, trace, blather
 pidfile=/var/run/supervisord.pid                                ; (supervisord pidfile;default supervisord.pid)
 childlogdir=<%= @node['supervisor']['log_dir'] %>               ; ('AUTO' child log dir, default $TEMP)
+nocleanup=<%= @node['supervisor']['nocleanup'] %>               ; if true, retain child log files at startup, default false
 <% if @supervisor_version && @supervisor_version.match(/^3/) %>
 
 ; minfds & minprocs first appeared in supervisord 3.0

--- a/templates/default/supervisord.conf.erb
+++ b/templates/default/supervisord.conf.erb
@@ -27,12 +27,12 @@ logfile_backups=<%= @node['supervisor']['logfile_backups'] %>   ; number of back
 loglevel=<%= @node['supervisor']['loglevel'] %>                 ; critical, error, warn, info, debug, trace, blather
 pidfile=/var/run/supervisord.pid                                ; (supervisord pidfile;default supervisord.pid)
 childlogdir=<%= @node['supervisor']['log_dir'] %>               ; ('AUTO' child log dir, default $TEMP)
-nocleanup=<%= @node['supervisor']['nocleanup'] %>               ; if true, retain child log files at startup, default false
 <% if @supervisor_version && @supervisor_version.match(/^3/) %>
 
-; minfds & minprocs first appeared in supervisord 3.0
+; minfds, minprocs & nocleanup first appeared in supervisord 3.0
 minfds = <%= @supervisord_minfds %>
 minprocs = <%= @supervisord_minprocs %>
+nocleanup=<%= @supervisord_nocleanup %>
 <% end %>
 
 ; the below section must remain in the config file for RPC


### PR DESCRIPTION
set the `nocleanup` flag in `supervisord.conf`

from http://supervisord.org/configuration.html

> `Prevent supervisord from clearing any existing AUTO chlild log files at startup time. Useful for debugging.`