### PR TITLE
Fix Travis CI test error

### DIFF
--- a/.kitchen.travis.yml
+++ b/.kitchen.travis.yml
@@ -2,9 +2,3 @@
 driver:
   name: docker
   require_chef_omnibus: "<%= ENV['CHEF_VERSION'] || 'latest' %>"
-  binary: "./docker"
-  socket: tcp://docker.poise.io:443
-  tls_verify: true
-  tls_cacert: ".docker.ca"
-  tls_cert: ".docker.pem"
-  tls_key: ".docker.key"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
-sudo: false
+sudo: required
 cache: bundler
 language: ruby
+services:
+  - docker
 rvm:
-- 2.1.4
+- 2.1.6
 env:
   matrix:
   - CHEF_VERSION="11"
@@ -10,18 +12,15 @@ env:
   global:
   - USE_SYSTEM_GECODE=true
   - KITCHEN_LOCAL_YAML=.kitchen.travis.yml
-  - secure: lNU84s6dn1eXYHSBMPqjM219OfN2Cx8XKjcsXsb1UTV8BASfClWdsJuV/I5uwKMTHgnB+rK945BzA28SmCF2ixhLKbEbjh8TcnIf2s6qyxUWZMXEeYgBdW19ylD5ZiiIdLBvoz0tdrN+0uJwEENADCfQt/AAtD7ojuqa3oG+ZV8=
 before_install:
 - curl -o ~/gecode.tar.gz https://poise-gecode.s3.amazonaws.com/gecode-3.7.3-ubuntu12.04-x86_64.tar.gz
 - tar xzf ~/gecode.tar.gz -C ~
 - rm ~/gecode.tar.gz
+- gem install bundler
 - bundle config build.dep_selector "--with-cflags=\"-I$HOME/gecode-3.7.3/include\"
   --with-cppflags=\"-I$HOME/gecode-3.7.3/include\" --with-ldflags=\"-L$HOME/gecode-3.7.3/lib
   -Wl,-rpath=$HOME/gecode-3.7.3/lib\""
 bundler_args: "--deployment --binstubs"
 script:
 - "./bin/foodcritic ."
-- openssl rsa -in .docker.pem -passin env:KITCHEN_DOCKER_PASS -out .docker.key
-- wget https://get.docker.io/builds/Linux/x86_64/docker-latest -O docker
-- chmod +x docker
 - "./bin/kitchen test -d always"


### PR DESCRIPTION
A test error occurred in Travis CI when pull request, because can not get the “.docker.key” file.
Travis CI has already provided Docker environment. I changed to use Travis CI’s Docker environment.
