### PR TITLE
Don't use python cookbook anymore

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,11 +3,11 @@ maintainer        "Noah Kantrowitz"
 maintainer_email  "noah@coderanger.net"
 license           "Apache 2.0"
 description       "Installs supervisor and provides resources to configure services"
-version           "0.4.12"
+version           "0.4.13"
 
 recipe "supervisor", "Installs and configures supervisord"
 
-depends "python"
+depends "poise-python"
 
 %w{ ubuntu debian redhat centos fedora amazon smartos raspbian }.each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe "python"
+include_recipe "poise-python"
 
 # foodcritic FC023: we prefer not having the resource on non-smartos
 if platform_family?("smartos")


### PR DESCRIPTION
    Python cookbook is being deprecated in favor of poise-python. Also,
    python cookbook does not work with Chef 13.