### PR TITLE
Chef 13 compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,7 +4,9 @@ driver:
 
 platforms:
 - name: ubuntu-16.04
+- name: ubuntu-14.04
 - name: debian-9
+- name: debian-8
 
 suites:
 - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,21 +1,13 @@
 driver:
   name: vagrant
-  require_chef_omnibus: true
-
-chef_versions:
-- 11
-- 12
+  require_chef_omnibus: 13
 
 platforms:
-- name: ubuntu-12.04
-  run_list:
-  - recipe[apt]
-- name: ubuntu-10.04
-  run_list:
-    - recipe[apt]
-- name: centos-6.4
+- name: ubuntu-16.04
+- name: debian-9
 
 suites:
 - name: default
   run_list:
+  - recipe[apt]
   - recipe[supervisor]

--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-site :opscode
+source 'https://supermarket.chef.io'
 metadata
 
 group :integration do

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,14 +1,14 @@
-name              "supervisor"
-maintainer        "Noah Kantrowitz"
-maintainer_email  "noah@coderanger.net"
-license           "Apache 2.0"
-description       "Installs supervisor and provides resources to configure services"
-version           "0.4.12"
+name              'supervisor'
+maintainer        'Noah Kantrowitz'
+maintainer_email  'noah@coderanger.net'
+license           'Apache 2.0'
+description       'Installs supervisor and provides resources to configure services'
+version           '0.5.0'
 
-recipe "supervisor", "Installs and configures supervisord"
+recipe 'supervisor', 'Installs and configures supervisord'
 
-depends "python"
+depends 'poise-python', '~> 1.6.0'
 
-%w{ ubuntu debian redhat centos fedora amazon smartos raspbian }.each do |os|
+%w( ubuntu debian redhat centos fedora amazon smartos raspbian ).each do |os|
   supports os
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,6 +17,11 @@
 # limitations under the License.
 #
 
+# Install
+python_runtime 'supervisor' do
+  version '2.7'
+end
+
 # foodcritic FC023: we prefer not having the resource on non-smartos
 if platform_family?("smartos")
   package "py27-expat" do
@@ -24,9 +29,9 @@ if platform_family?("smartos")
   end
 end
 
-package 'python-pip'
 python_package "supervisor" do
   action :upgrade
+  python 'supervisor'
   version node['supervisor']['version'] if node['supervisor']['version']
 end
 
@@ -84,7 +89,7 @@ when "amazon", "centos", "debian", "fedora", "redhat", "ubuntu", "raspbian"
     variables({
       # TODO: use this variable in the debian platform-family template
       # instead of altering the PATH and calling "which supervisord".
-      :supervisord => "/usr/bin/supervisord"
+      :supervisord => "/usr/local/bin/supervisord"
     })
   end
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 # Install
 python_runtime 'supervisor' do
-  version '2.7'
+  version '2'
 end
 
 # foodcritic FC023: we prefer not having the resource on non-smartos

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,8 +17,6 @@
 # limitations under the License.
 #
 
-include_recipe "python"
-
 # foodcritic FC023: we prefer not having the resource on non-smartos
 if platform_family?("smartos")
   package "py27-expat" do
@@ -26,7 +24,8 @@ if platform_family?("smartos")
   end
 end
 
-python_pip "supervisor" do
+package 'python-pip'
+python_package "supervisor" do
   action :upgrade
   version node['supervisor']['version'] if node['supervisor']['version']
 end
@@ -85,7 +84,7 @@ when "amazon", "centos", "debian", "fedora", "redhat", "ubuntu", "raspbian"
     variables({
       # TODO: use this variable in the debian platform-family template
       # instead of altering the PATH and calling "which supervisord".
-      :supervisord => "#{node['python']['prefix_dir']}/bin/supervisord"
+      :supervisord => "/usr/bin/supervisord"
     })
   end
 


### PR DESCRIPTION
Updated cookbook so that it depends on "poise-python" cookbook instead of the deprecated "python" cookbook.